### PR TITLE
change id to bigIncrements to better match laravel new migration conventions

### DIFF
--- a/migrations/2019_02_25_231036_create_scheduled_notifications_table.php
+++ b/migrations/2019_02_25_231036_create_scheduled_notifications_table.php
@@ -14,7 +14,7 @@ class CreateScheduledNotificationsTable extends Migration
     public function up()
     {
         Schema::create(config('snooze.table'), function (Blueprint $table) {
-            $table->increments('id');
+            $table->id();
 
             $table->string('target_id')->nullable();
             $table->string('target_type');


### PR DESCRIPTION
most of laravel migrations now use big increments for id through using $table->id()

Notification is something that rapidly grow so it make more sense to use big increment for id too or uuid 7 / ulid

this PR is about that