### PR TITLE
Add PHP 8.4 support and align CI matrix with PHP constraint

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,12 +12,8 @@ jobs:
       max-parallel: 15
       matrix:
         laravel-version: [^10.0, ^11.0, ^12.0]
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.2', '8.3', '8.4']
         exclude:
-          - laravel-version: '^10.0'
-            php-versions: '8.1'
-          - laravel-version: '^11.0'
-            php-versions: '8.1'
           - laravel-version: '^12.0'
             php-versions: '8.2'
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
       max-parallel: 15
       matrix:
         laravel-version: [^10.0, ^11.0, ^12.0]
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
         exclude:
           - laravel-version: '^10.0'
             php-versions: '8.1'

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^10.0 | ^11.0 | ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0 | ^9.0",
+        "orchestra/testbench": "^8.0 | ^9.0 | ^10.0",
         "phpunit/phpunit": "^10.0 | ^11.0",
         "timacdonald/log-fake": "^2"
     },

--- a/src/ScheduledNotification.php
+++ b/src/ScheduledNotification.php
@@ -66,7 +66,7 @@ class ScheduledNotification
         ]));
     }
 
-    public static function getPendingNotifications(int $tolerance = null): \Illuminate\Database\Eloquent\Collection
+    public static function getPendingNotifications(?int $tolerance = null): \Illuminate\Database\Eloquent\Collection
     {
         $modelClass = self::getScheduledNotificationModelClass();
 


### PR DESCRIPTION
- Adds explicit nullable parameter type for PHP 8.4 compatibility
- Adds PHP 8.4 to GitHub Actions matrix
- Removes PHP 8.1 since composer.json requires PHP >= 8.2